### PR TITLE
Sine fix

### DIFF
--- a/params/sine_params.py
+++ b/params/sine_params.py
@@ -98,7 +98,7 @@ def create_params():
                                 data_points_per_file=10000,
                                 
                                 # Data directory
-                                data_dir='/home/somilb/Documents/Projects/visual_mpc/tmp'
+                                data_dir='./visual_mpc/tmp'
     )
     
     # Test parameters

--- a/training_utils/trainer_helper.py
+++ b/training_utils/trainer_helper.py
@@ -85,6 +85,8 @@ class TrainerHelper(object):
             # Note: This allows the user to specify how many checkpoints should be saved.
             # Tensorflow does not expose the parameter in tfe.Checkpoint for max_to_keep,
             # however under the hood it uses a Saver object so we can hack around this.
+            # Kaustav: this procedure runs unsuccessfully sometimes
+            '''
             from tensorflow.python.training.saver import Saver
             default_args = list(Saver.__init__.__code__.co_varnames)
             default_values = list(Saver.__init__.__defaults__)
@@ -95,7 +97,7 @@ class TrainerHelper(object):
                 Saver.__init__.__defaults__ = tuple(default_values)
             else:
                 assert(False)
-
+            '''
         # Save the checkpoint
         if epoch % self.p.ckpt_save_frequency == 0:
             self.checkpoint.save(os.path.join(self.ckpt_dir, 'ckpt'))


### PR DESCRIPTION
The number of checkpoints to save was causing issues in my system, so commented it out; The data creation for the sine did not have the path directory configured, so used a relative path for now.